### PR TITLE
Clarify dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 # install dependencies
 install:
 - pip install -r src/requirements.txt
-- pip install codecov
+- pip install codecov pdoc3 pytest pytest-cov
 # run tests
 script:
 - pytest

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,10 +1,7 @@
 flair>=0.7
 langdetect>=1.0.8
-numpy>=1.16.5
+numpy>=1.16.5,<1.20.0
 pandas>=1.0.3
 lxml>=4.6.2
 protobuf>=3.14.0
-pdoc3>=0.9.2
-pytest>=6.2.1
-pytest-cov>=2.10.1
 nltk>=3.4.5


### PR DESCRIPTION
- Added an upper limit to NumPy (<1.20), since I was having trouble with Flair not supporting NumPy 1.20 and above.
- Remove dependency on pdoc3, pytest and pytest-cov, since the software doesn't need them to work. They're only needed for development.
- Explicitly install pytest and pytest-cov in Travis CI, so the tests are performed and coverage updated in CI.