### PR TITLE
Tutorial improvements, up to but not including "Outliers filtering"

### DIFF
--- a/examples/text_preprocessing_tutorial.ipynb
+++ b/examples/text_preprocessing_tutorial.ipynb
@@ -21,20 +21,20 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "This tutorial demonstrates how to preprocess text to clean it up for the modeling. Usually, this analysis is performed manually and very time-consuming. Package helps to identify and filter different languages in some sentences of the text, not linguistically connected and corrupted sentences, and duplicated sentences.\n",
+    "This tutorial demonstrates how to preprocess text to clean it up for the modeling. Usually, this analysis is performed manually and very time-consuming. The textcl package helps to identify and filter out sentences in languages other than the target language, linguistically unconnected and corrupted sentences, and duplicated sentences.\n",
     "\n",
-    "Another feature of the package is to identify and filter outliers of the text scope. As outliers, we consider texts that don't belong contextually to the main topic of the text. It's important to be able to identify these anomalies without having labeled data, so we can have a general algorithm for the unstructured texts and find out the scope blocks.\n",
+    "Another feature of the package is to identify and filter out outliers from the text scope. As outliers, we consider texts that don't contextually belong to the main topic of the text. It's important to be able to identify these anomalies without having labeled data, so we can have a general algorithm for unstructured texts and find out the scope blocks.\n",
     "\n",
-    "In the tutorial, we will work with BBC data set and manually generated extra sentences to show all functions of the package. Overall package can be used with any text data set loaded as a Pandas data frame.\n",
+    "In this tutorial, we will work with the [BBC data set](https://github.com/alinapetukhova/textcl/blob/master/examples/prepared_bbc_dataset.csv) and additional manually generated sentences to demonstrate the package's functionality. Overall, the package can be used with any text data set loaded as a [Pandas data frame](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).\n",
     "\n",
-    "The following functions were implemented for the text cleaning:\n",
+    "The package contains the following functions for text cleaning:\n",
     "\n",
     "1. Filtering on language\n",
     "2. Filtering on Jaccard similarity\n",
     "3. Filtering on perplexity score\n",
     "4. Outliers filtering\n",
     "\n",
-    "The first three functions are working on the sentence level for each text in the scope and the outlier filtering function works on the full-text level. In the function were implemented 3 different outlier detection algorithms: [TONMF](https://arxiv.org/pdf/1701.01325.pdf), [RPCA](https://github.com/dganguli/robust-pca), [SVD](https://api.semanticscholar.org/CorpusID:123532178) with `l2` normalisation by default (can be change to the `l1`, `l2`, or `max` with `norm` parameter)."
+    "The first three functions work at the sentence level for each text in the scope. In turn, the outlier filtering function works at the level of the full text. The latter implements 3 different outlier detection algorithms: [TONMF](https://arxiv.org/pdf/1701.01325.pdf), [RPCA](https://github.com/dganguli/robust-pca), and [SVD](https://api.semanticscholar.org/CorpusID:123532178), with `l2` normalisation by default (can be changed to the `l1`, `l2`, or `max` via the `norm` parameter)."
    ]
   },
   {
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load package and dependencies"
+    "Load package and dependencies:"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Prepare input data from modified BBC dataset. First, you need to load the text data for the processing. Sample file places in the example folder of the project next to this tutorial. "
+    "Let's prepare the input data from the modified BBC dataset. First, load the text data. The sample file is located in the `examples` folder, next to this tutorial."
    ]
   },
   {
@@ -74,8 +74,8 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Num texts in the data set: 21\n"
      ]
@@ -92,34 +92,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's necessary to have column `text` in the data (default name). If you don't have `text` column you will need to specify the name for [`split_into_sentences()`](https://alinapetukhova.github.io/textcl/docs/preprocessing.html#textcl.preprocessing.split_into_sentences) function using `text_col` parameter. Source file from this example structured as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['index', 'topic_name', 'text'], dtype='object')"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "input_texts_df.columns"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In this example we will use a subset of BBC News data set containing 5 topics (business, entertainment, politics, sport, tech)  with manually inserted texts to display the capabilities of the package (see examples below). Here is how the dataset looks like:"
+    "In this example we'll use a subset of the BBC News data set containing 5 topics (business, entertainment, politics, sport, tech) with manually inserted texts to demonstrate the capabilities of the package. Here's how the dataset looks like:"
    ]
   },
   {
@@ -329,19 +302,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To be able to process/filter sentences from the data set separately we first need to split given text into the sentences as rows in Pandas dataframe.\n",
+    "To be able to process/filter sentences from the data set separately we first need to split our texts into sentences as rows in a Pandas data frame. The [`split_into_sentences()`](https://alinapetukhova.github.io/textcl/docs/preprocessing.html#textcl.preprocessing.split_into_sentences) function is used for this purpose.\n",
     "\n",
-    "If `sentence_col` is not specified as a parameter, created sentences will be saved in the `sentence` column.|"
+    "Notice the data loaded in the previous section has a column named `text`. By default, the `split_into_sentences()` function expects to find texts in this column. However, an alternative name for this column can be specified in the function's `text_col` parameter.\n",
+    "\n",
+    "Splitting the data set texts into sentences is done as follows, using the `split_into_sentences()` function:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Num sentences before filtering: 319\n"
      ]
@@ -356,81 +331,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Arter the splitting text data set into sentences, the amount of rows increased from 21 to 319. Let's review them:"
+    "After splitting text data set into sentences, the number of rows increased from 21 to 319. Let's review them:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>index</th>\n",
-       "      <th>topic_name</th>\n",
-       "      <th>text</th>\n",
-       "      <th>sentence</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>business</td>\n",
-       "      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n",
-       "      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0</td>\n",
-       "      <td>business</td>\n",
-       "      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n",
-       "      <td>James Wareham, a lawyer representing one of t...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0</td>\n",
-       "      <td>business</td>\n",
-       "      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n",
-       "      <td>The remaining $36m will be paid by the directo...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0</td>\n",
-       "      <td>business</td>\n",
-       "      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n",
-       "      <td>But, a spokesman for the prosecutor, New York ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0</td>\n",
-       "      <td>business</td>\n",
-       "      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n",
-       "      <td>Corporate governance experts said that if the...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
        "   index topic_name                                               text  \\\n",
        "0      0   business  WorldCom bosses' $54m payout  Ten former direc...   \n",
@@ -445,16 +356,23 @@
        "2  The remaining $36m will be paid by the directo...  \n",
        "3  But, a spokesman for the prosecutor, New York ...  \n",
        "4   Corporate governance experts said that if the...  "
-      ]
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>index</th>\n      <th>topic_name</th>\n      <th>text</th>\n      <th>sentence</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>business</td>\n      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0</td>\n      <td>business</td>\n      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n      <td>James Wareham, a lawyer representing one of t...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0</td>\n      <td>business</td>\n      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n      <td>The remaining $36m will be paid by the directo...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0</td>\n      <td>business</td>\n      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n      <td>But, a spokesman for the prosecutor, New York ...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0</td>\n      <td>business</td>\n      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n      <td>Corporate governance experts said that if the...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 6,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 5
     }
    ],
    "source": [
     "split_input_texts_df.head()"
    ]
+  },
+  {
+   "source": [
+    "As show in this example, the `split_into_sentences()` places sentences in the `sentence` column by default. This can be changed using the function's `sentence_col` parameter."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -467,21 +385,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's, check that the textcl is working by testing the language filtering algorithm with manually inserted texts in Russian and Turkish language to the initial set.\n",
+    "Let's check how the language filtering function works with manually inserted texts in Russian and Turkish languages to the initial set.\n",
     "\n",
-    "To do that we will use function [`language_filtering()`](https://alinapetukhova.github.io/textcl/docs/preprocessing.html#textcl.preprocessing.language_filtering), that can filter sentences by the language. Inputs to this function should be Pandas dataframe with sentence column, threshold value, and target language. Language score is the threshold used for filtering with the default value of 0.99. In the function was used the `detect_language` function from the package `langdetect`, that returns probabilities of text belonging to a certain language. All sentences below threshold will be filtered."
+    "To do this we'll use the [`language_filtering()`](https://alinapetukhova.github.io/textcl/docs/preprocessing.html#textcl.preprocessing.language_filtering) function, which filters sentences by language. The input to this function should be a Pandas data frame with sentence column, threshold value, and target language. Language score is the threshold used for filtering, with the default value of 0.99. The function makes use the `detect_language` function from the package [langdetect](https://pypi.org/project/langdetect/), which returns probabilities of a text belonging to a certain language. All sentences below this threshold will be filtered out."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Num sentences after language filtering: 280\n"
+      "Num sentences after language filtering: 281\n"
      ]
     }
    ],
@@ -494,134 +412,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The amount of rows with sentences was reduced from 319 to 281. Join sentences to the initial texts to review the results:"
+    "The number of rows with sentences was reduced from 319 to 281. Join sentences to the initial texts to review the results:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>index</th>\n",
-       "      <th>sentence</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>Profits slide at India's Dr Reddy  Profits at ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>Liberian economy starts to grow  The Liberian ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>Singer Ian Brown 'in gig arrest'  Former Stone...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>Blue beat U2 to top France honour  Irish band ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>6</td>\n",
-       "      <td>Housewives lift Channel 4 ratings  The debut o...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>9</td>\n",
-       "      <td>Observers to monitor UK election  Ministers wi...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>10</td>\n",
-       "      <td>Lib Dems highlight problem debt  People vulner...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>11</td>\n",
-       "      <td>Minister defends hunting ban law  The law bann...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>12</td>\n",
-       "      <td>Legendary Dutch boss Michels dies  Legendary D...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>13</td>\n",
-       "      <td>Connors boost for British tennis  Former world...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>14</td>\n",
-       "      <td>Sociedad set to rescue Mladenovic  Rangers are...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>15</td>\n",
-       "      <td>Mobile games come of age  The BBC News website...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>16</td>\n",
-       "      <td>PlayStation 3 processor unveiled  The Cell pro...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>17</td>\n",
-       "      <td>PC photo printers challenge printed pictures c...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>18</td>\n",
-       "      <td>PC photo printers challenge pros  Home printed...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>19</td>\n",
-       "      <td>data clear additional 78.0 long-term 43 those)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>20</td>\n",
-       "      <td>Janice Dean currently serves as senior meteoro...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
        "    index                                           sentence\n",
        "0       0  WorldCom bosses' $54m payout  Ten former direc...\n",
@@ -642,11 +443,11 @@
        "15     18  PC photo printers challenge pros  Home printed...\n",
        "16     19     data clear additional 78.0 long-term 43 those)\n",
        "17     20  Janice Dean currently serves as senior meteoro..."
-      ]
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>index</th>\n      <th>sentence</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>Profits slide at India's Dr Reddy  Profits at ...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2</td>\n      <td>Liberian economy starts to grow  The Liberian ...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>4</td>\n      <td>Singer Ian Brown 'in gig arrest'  Former Stone...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>5</td>\n      <td>Blue beat U2 to top France honour  Irish band ...</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>6</td>\n      <td>Housewives lift Channel 4 ratings  The debut o...</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>9</td>\n      <td>Observers to monitor UK election  Ministers wi...</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>10</td>\n      <td>Lib Dems highlight problem debt  People vulner...</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>11</td>\n      <td>Minister defends hunting ban law  The law bann...</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>12</td>\n      <td>Legendary Dutch boss Michels dies  Legendary D...</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>13</td>\n      <td>Connors boost for British tennis  Former world...</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>14</td>\n      <td>Sociedad set to rescue Mladenovic  Rangers are...</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>15</td>\n      <td>Mobile games come of age  The BBC News website...</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>16</td>\n      <td>PlayStation 3 processor unveiled  The Cell pro...</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>17</td>\n      <td>PC photo printers challenge printed pictures c...</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>18</td>\n      <td>PC photo printers challenge pros  Home printed...</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>19</td>\n      <td>data clear additional 78.0 long-term 43 those)</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>20</td>\n      <td>Janice Dean currently serves as senior meteoro...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 8,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 7
     }
    ],
    "source": [
@@ -657,7 +458,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see texts with index 3 (Turkish), 7 (Russian), 8 (Turkish) were removed."
+    "As we can see, texts with index 3 (Turkish), 7 (Russian), 8 (Turkish) were removed."
    ]
   },
   {
@@ -671,7 +472,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Function [`jaccard_sim_filtering()`](https://alinapetukhova.github.io/textcl/docs/preprocessing.html#textcl.preprocessing.jaccard_sim_filtering) used to filter sentences by Jaccard similarity. It represents each sentence as an array of tokens and finds the intersection between two arrays. Using the intersection calculated the similarity score and if it's below the given threshold sentence will be filtered."
+    "Function [`jaccard_sim_filtering()`](https://alinapetukhova.github.io/textcl/docs/preprocessing.html#textcl.preprocessing.jaccard_sim_filtering) is used to filter sentences by [Jaccard similarity](https://en.wikipedia.org/wiki/Jaccard_index). It represents each sentence as an array of tokens and finds the intersection between two arrays. Using the intersection, the similarity score is calculated; if it's above the specified `threshold`, a sentence will be filtered out."
    ]
   },
   {
@@ -680,10 +481,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Num sentences after Jaccard sim filtering: 257\n"
+      "Num sentences after Jaccard sim filtering: 258\n"
      ]
     }
    ],
@@ -696,7 +497,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The amount of rows with sentences was reduced from 281 to 258. Join sentences to the initial texts to review the results:"
+    "The number of rows with sentences was reduced from 281 to 258. Join sentences to the initial texts to review the results:"
    ]
   },
   {
@@ -705,120 +506,8 @@
    "metadata": {},
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>index</th>\n",
-       "      <th>sentence</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>Profits slide at India's Dr Reddy  Profits at ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>Liberian economy starts to grow  The Liberian ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>Singer Ian Brown 'in gig arrest'  Former Stone...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>Blue beat U2 to top France honour  Irish band ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>6</td>\n",
-       "      <td>Housewives lift Channel 4 ratings  The debut o...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>9</td>\n",
-       "      <td>Observers to monitor UK election  Ministers wi...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>10</td>\n",
-       "      <td>Lib Dems highlight problem debt  People vulner...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>11</td>\n",
-       "      <td>Minister defends hunting ban law  The law bann...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>12</td>\n",
-       "      <td>Legendary Dutch boss Michels dies  Legendary D...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>13</td>\n",
-       "      <td>Connors boost for British tennis  Former world...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>14</td>\n",
-       "      <td>Sociedad set to rescue Mladenovic  Rangers are...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>15</td>\n",
-       "      <td>Mobile games come of age  The BBC News website...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>16</td>\n",
-       "      <td>PlayStation 3 processor unveiled  The Cell pro...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>18</td>\n",
-       "      <td>PC photo printers challenge pros  Home printed...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>19</td>\n",
-       "      <td>data clear additional 78.0 long-term 43 those)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>20</td>\n",
-       "      <td>Janice Dean currently serves as senior meteoro...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
        "    index                                           sentence\n",
        "0       0  WorldCom bosses' $54m payout  Ten former direc...\n",
@@ -838,11 +527,11 @@
        "14     18  PC photo printers challenge pros  Home printed...\n",
        "15     19     data clear additional 78.0 long-term 43 those)\n",
        "16     20  Janice Dean currently serves as senior meteoro..."
-      ]
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>index</th>\n      <th>sentence</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>WorldCom bosses' $54m payout  Ten former direc...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>Profits slide at India's Dr Reddy  Profits at ...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2</td>\n      <td>Liberian economy starts to grow  The Liberian ...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>4</td>\n      <td>Singer Ian Brown 'in gig arrest'  Former Stone...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>5</td>\n      <td>Blue beat U2 to top France honour  Irish band ...</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>6</td>\n      <td>Housewives lift Channel 4 ratings  The debut o...</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>9</td>\n      <td>Observers to monitor UK election  Ministers wi...</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>10</td>\n      <td>Lib Dems highlight problem debt  People vulner...</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>11</td>\n      <td>Minister defends hunting ban law  The law bann...</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>12</td>\n      <td>Legendary Dutch boss Michels dies  Legendary D...</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>13</td>\n      <td>Connors boost for British tennis  Former world...</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>14</td>\n      <td>Sociedad set to rescue Mladenovic  Rangers are...</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>15</td>\n      <td>Mobile games come of age  The BBC News website...</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>16</td>\n      <td>PlayStation 3 processor unveiled  The Cell pro...</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>18</td>\n      <td>PC photo printers challenge pros  Home printed...</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>19</td>\n      <td>data clear additional 78.0 long-term 43 those)</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>20</td>\n      <td>Janice Dean currently serves as senior meteoro...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 10
     }
    ],
    "source": [
@@ -853,7 +542,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Text with id=17 was removed as it partially duplicates text with id=18."
+    "Text with $id=17$ was removed as it was a partial duplicate of text with $id=18$."
    ]
   },
   {
@@ -867,7 +556,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Function [`perplexity_filtering()`](https://alinapetukhova.github.io/textcl/docs/preprocessing.html#textcl.preprocessing.perplexity_filtering) used to filter sentences by perplexity. The first step creates contextual tokens to capture latent syntactic-semantic information provided by the package `pytorch_pretrained_bert` with pretrained `openai-gpt` tokenizer and use GPT as Language Model with `OpenAIGPTLMHeadModel`. Perplexity calculated as `exp(loss)` (where **loss** is language modeling loss of a particular token)."
+    "Function [`perplexity_filtering()`](https://alinapetukhova.github.io/textcl/docs/preprocessing.html#textcl.preprocessing.perplexity_filtering) is used to filter sentences by perplexity, i.e., when they are linguistically incorrect and/or unconnected with the remaining text. The first step creates contextual tokens to capture latent syntactic-semantic information provided by the package [pytorch_pretrained_bert](https://pypi.org/project/pytorch-pretrained-bert/) with pretrained `openai-gpt` tokenizer and use of GPT as Language Model with `OpenAIGPTLMHeadModel`. Perplexity calculated as `exp(loss)` (where **loss** is language modeling loss of a particular token)."
    ]
   },
   {
@@ -876,16 +565,14 @@
    "metadata": {},
    "outputs": [
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
-      "ftfy or spacy is not installed using BERT BasicTokenizer instead of SpaCy & ftfy.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "100%|██████████| 478750579/478750579 [00:18<00:00, 26417458.84B/s]\n",
+      "100%|██████████| 656/656 [00:00<00:00, 734899.42B/s]\n",
+      "100%|██████████| 815973/815973 [00:00<00:00, 1480173.25B/s]\n",
+      "100%|██████████| 458495/458495 [00:00<00:00, 998134.29B/s]\n",
+      "ftfy or spacy is not installed using BERT BasicTokenizer instead of SpaCy & ftfy.\n",
       "Num sentences after perplexity filtering: 246\n"
      ]
     }
@@ -899,7 +586,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The amount of rows with sentences was resuced from 258 to the 246. Join sentences to the initial texts to review the results:"
+    "The number of rows with sentences was resuced from 258 to the 246. Join sentences to the initial texts to review the results:"
    ]
   },
   {
@@ -1050,7 +737,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Text with id=19 was removed because sentence `data clear additional 78.0 long-term 43 those)` is not linguistically correct."
+    "Text with id=19 was removed because sentence *\"data clear additional 78.0 long-term 43 those)\"* is not linguistically correct."
    ]
   },
   {
@@ -1968,9 +1655,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python38564bitenv3bad592dbf03427abc69ad63ff60f5f1",
+   "display_name": "Python 3.8.5 64-bit ('env')"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1982,7 +1668,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.5-final"
   },
   "pycharm": {
    "stem_cell": {
@@ -1991,6 +1677,11 @@
      "collapsed": false
     },
     "source": []
+   }
+  },
+  "metadata": {
+   "interpreter": {
+    "hash": "ef6fb3f656d4ea79ca9f8b9c23b276d8478a1b3139acf0a655e7d2ebf2ef5905"
    }
   }
  },


### PR DESCRIPTION
Revised tutorial up until (but not including) "Outliers filtering" section.

Things to do:

* Re-read the revised parts to see if anything is technically incorrect. The order of some things was slightly changed.
* Check the first sentence: "...to clean it up for the modeling." Be a little more concrete (but not too much) on what will be this "modelling".
* I've changed the first paragraph of the "Filtering on Jaccard similarity" section, namely the part of filtering out sentences **above** the similarity threshold. If I'm understanding this incorrectly, please fix the sentence.
* It's difficult to understand what you mean with the first paragraph of "Filtering on perplexity score" section. Give it a look and rephrase if possible.